### PR TITLE
Fix possibility to corrupt repeater state

### DIFF
--- a/src/repeatedly.gleam
+++ b/src/repeatedly.gleam
@@ -8,7 +8,7 @@ pub type Repeater(state)
 pub fn call(
   delay_ms: Int,
   state: state,
-  function: fn(state, Int) -> a,
+  function: fn(state, Int) -> state,
 ) -> Repeater(state)
 
 /// Stop the repeater, preventing it from triggering again.
@@ -35,7 +35,7 @@ pub fn stop(repeater: Repeater(state)) -> Nil
 @external(javascript, "./repeatedly_ffi.mjs", "replace")
 pub fn set_function(
   repeater: Repeater(state),
-  function: fn(state, Int) -> a,
+  function: fn(state, Int) -> state,
 ) -> Nil
 
 /// Set the repeater state.


### PR DESCRIPTION
Hello! Love the package for simple processes. I accidentally corrupted my repeater state, and realized the following program will compile but will cause an Erlang runtime error when it reaches the second loop:

```gleam
import gleam/erlang/process
import repeatedly

pub fn main() {
  repeatedly.call(500, 0, fn(state, _) {
    state + 1
    "Corrupt state"
  })

  process.sleep_forever()
}
```

This is because the return type of the function does not have to match the type of the state passed back into the function, and the Gleam compiler is not aware that the return value will be passed back in later. This PR should fix that :)